### PR TITLE
rtk-query sample for better performance

### DIFF
--- a/preqin-spa/public/index.html
+++ b/preqin-spa/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Preqin SPA</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/preqin-spa/src/components/InvestorTable.tsx
+++ b/preqin-spa/src/components/InvestorTable.tsx
@@ -1,21 +1,76 @@
-import { useEffect } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import { AppDispatch, RootState } from "../store";
-import { fetchInvestors } from "../services/api";
-import { setInvestors } from "../store/investorsSlice";
+// InvestorsTable using axios
 
+// import { useEffect } from "react";
+// import { useDispatch, useSelector } from "react-redux";
+// import { AppDispatch, RootState } from "../store";
+// import { fetchInvestors } from "../services/api";
+// import { setInvestors } from "../store/investorsSlice";
+
+// import CustomTable from "./ui-common/CustomTable";
+
+// const InvestorsTable = () => {
+//   const dispatch = useDispatch<AppDispatch>();
+//   const investors = useSelector((state: RootState) => state.investors.list);
+
+//   useEffect(() => {
+//     const firmIds = [2670, 2792, 332, 3611];
+//     fetchInvestors(firmIds).then((data) => {
+//       dispatch(setInvestors(data));
+//     });
+//   }, [dispatch]);
+
+//   return (
+//     <>
+//       <h2 style={{ margin: "10px" }}>Investors</h2>
+//       {investors.length > 0 && (
+//         <CustomTable
+//           data={investors}
+//           tableType={"investors"}
+//           columns={[
+//             { id: "firm_id", label: "FirmId" },
+//             { id: "firm_name", label: "FirmName" },
+//             { id: "firm_type", label: "Type" },
+//             { id: "date_added", label: "DateAdded", dateTypeBool: true },
+//             { id: "address", label: "Address" },
+//           ]}
+//         />
+//       )}
+//     </>
+//   );
+// };
+
+// export default InvestorsTable;
+
+// InvestorsTable using rtk-query for better performance
+
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { AppDispatch } from "../store";
+import { useFetchInvestorsQuery } from "../services/apiSlice";
 import CustomTable from "./ui-common/CustomTable";
+import { setInvestors } from "../store/investorsSlice";
 
 const InvestorsTable = () => {
   const dispatch = useDispatch<AppDispatch>();
-  const investors = useSelector((state: RootState) => state.investors.list);
+
+  // Define firm IDs
+  const firmIds = [2670, 2792, 332, 3611];
+
+  // Fetch investors using rtk-query hook
+  const {
+    data: investors = [],
+    error,
+    isLoading,
+  } = useFetchInvestorsQuery(firmIds);
 
   useEffect(() => {
-    const firmIds = [2670, 2792, 332, 3611];
-    fetchInvestors(firmIds).then((data) => {
-      dispatch(setInvestors(data));
-    });
-  }, [dispatch]);
+    if (investors.length > 0) {
+      dispatch(setInvestors(investors));
+    }
+  }, [dispatch, investors]);
+
+  if (isLoading) return <p>Loading...</p>;
+  if (error) return <p>Error fetching investors</p>;
 
   return (
     <>

--- a/preqin-spa/src/services/apiSlice.ts
+++ b/preqin-spa/src/services/apiSlice.ts
@@ -1,0 +1,32 @@
+//  rtk-query to handle caching and avoid unnecessary backend calls.
+//  rtk-query is part of Redux Toolkit
+//  It provides a powerful way to manage server-side data, including caching, synchronization, and automatic re-fetching
+
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import { Investor, Commitment } from "./api";
+
+const API_BASE_URL = "http://127.0.0.1:8000";
+
+export const apiSlice = createApi({
+  reducerPath: "api",
+  baseQuery: fetchBaseQuery({ baseUrl: API_BASE_URL }),
+  endpoints: (builder) => ({
+    fetchInvestors: builder.query<Investor[], number[]>({
+      query: (firmIds) => ({
+        url: "/api/investors",
+        transformResponse: (response: Investor[]) =>
+          response.filter((investor) => firmIds.includes(investor.firm_id)),
+      }),
+    }),
+
+    fetchCommitment: builder.query<
+      Commitment[],
+      { assetClass: string; investorId: number }
+    >({
+      query: ({ assetClass, investorId }) =>
+        `/api/investor/commitment/${assetClass}/${investorId}`,
+    }),
+  }),
+});
+
+export const { useFetchInvestorsQuery, useFetchCommitmentQuery } = apiSlice;

--- a/preqin-spa/src/store/index.ts
+++ b/preqin-spa/src/store/index.ts
@@ -1,10 +1,14 @@
 import { configureStore } from "@reduxjs/toolkit";
 import investorsReducer from "./investorsSlice";
+import { apiSlice } from "../services/apiSlice";
 
 export const store = configureStore({
   reducer: {
     investors: investorsReducer,
+    [apiSlice.reducerPath]: apiSlice.reducer,
   },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(apiSlice.middleware),
 });
 
 // Infer the `RootState` and `AppDispatch` types from the store itself


### PR DESCRIPTION
Adding rtk-query sample with home page `"/"` to fetch `/api/Investors`

- rtk-query to handle caching and avoid unnecessary backend calls.
- rtk-query is part of Redux Toolkit
- rtk-query provides a powerful way to manage server-side data, including caching, synchronization, and automatic re-fetching

<img width="1493" alt="image" src="https://github.com/user-attachments/assets/c24af839-0287-477e-9a69-c2e81808f3d9">
